### PR TITLE
[FEATURE] Service Name Resolution

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    minitest (5.10.1)
     rake (10.0.4)
 
 PLATFORMS
@@ -13,4 +14,8 @@ PLATFORMS
 
 DEPENDENCIES
   aws4!
+  minitest
   rake
+
+BUNDLED WITH
+   1.13.7

--- a/aws4.gemspec
+++ b/aws4.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |s|
   s.executables  = []
   s.homepage     = 'http://github.com/cmdrkeene/aws4'
 
+  s.add_development_dependency "minitest"
   s.add_development_dependency "rake"
 end
 

--- a/lib/aws4/signer.rb
+++ b/lib/aws4/signer.rb
@@ -14,6 +14,7 @@ module AWS4
       @access_key = config[:access_key] || config["access_key"]
       @secret_key = config[:secret_key] || config["secret_key"]
       @region = config[:region] || config["region"]
+      @service = config[:service]
     end
 
     def sign(method, uri, headers, body, debug = false)
@@ -21,7 +22,7 @@ module AWS4
       @uri = uri
       @headers = headers
       @body = body
-      @service = @uri.host.split(".", 2)[0]
+      @service ||= @uri.host.split(".", 2)[0]
       date_header = headers["Date"] || headers["DATE"] || headers["date"]
       @date = (date_header ? Time.parse(date_header) : Time.now).utc.strftime(RFC8601BASIC)
       dump if debug
@@ -82,11 +83,11 @@ module AWS4
     end
 
     def hmac(key, value)
-      OpenSSL::HMAC.digest(OpenSSL::Digest::Digest.new('sha256'), key, value)
+      OpenSSL::HMAC.digest(OpenSSL::Digest.new('sha256'), key, value)
     end
 
     def hexhmac(key, value)
-      OpenSSL::HMAC.hexdigest(OpenSSL::Digest::Digest.new('sha256'), key, value)
+      OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha256'), key, value)
     end
 
     def dump


### PR DESCRIPTION
Breaks for ES because of the way the `#sign` method figures out the service-name from URI host, so we allow it to be overridden in the initializer 